### PR TITLE
Adds possibility to add sprintf-values

### DIFF
--- a/src/Formatter/SprintfFormatter.php
+++ b/src/Formatter/SprintfFormatter.php
@@ -2,12 +2,6 @@
 
 namespace Budgegeria\IntlFormat\Formatter;
 
-use IntlCalendar;
-use IntlTimeZone;
-use DateTimeInterface;
-use DateTimeZone;
-use Budgegeria\IntlFormat\Exception\InvalidValueException;
-
 class SprintfFormatter implements FormatterInterface
 {
     /**
@@ -23,6 +17,6 @@ class SprintfFormatter implements FormatterInterface
      */
     public function has($typeSpecifier)
     {
-        return (bool) preg_match('/[\+\-]?(\'?.)?\-?\d*(?:\.?\d*)[%bcdeEfFgGosuxX]/', $typeSpecifier);
+        return (bool) preg_match('/[\+\-]?(\'?.)?(?:\-\-)?\d*(?:\.?\d*)[%bcdeEfFgGosuxX]/', $typeSpecifier);
     }
 }

--- a/src/Formatter/SprintfFormatter.php
+++ b/src/Formatter/SprintfFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Budgegeria\IntlFormat\Formatter;
+
+use IntlCalendar;
+use IntlTimeZone;
+use DateTimeInterface;
+use DateTimeZone;
+use Budgegeria\IntlFormat\Exception\InvalidValueException;
+
+class SprintfFormatter implements FormatterInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function formatValue($typeSpecifier, $value)
+    {
+        return sprintf('%' . $typeSpecifier, $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function has($typeSpecifier)
+    {
+        return (bool) preg_match('/[\+\-]?(\'?.)?\-?\d*(?:\.?\d*)[%bcdeEfFgGosuxX]/', $typeSpecifier);
+    }
+}

--- a/tests/Formatter/SprintfFormatterTest.php
+++ b/tests/Formatter/SprintfFormatterTest.php
@@ -17,6 +17,14 @@ class SprintfFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($formatter->has($typeSpecifier));
     }
 
+    /** @dataProvider provideTypeSpecifier */
+    public function testFormat($typeSpecifier, $value, $expected)
+    {
+        $formatter = new SprintfFormatter();
+
+        $this->assertEquals($expected, $formatter->formatValue($typeSpecifier, $value));
+    }
+
     public function testHasIsFalse()
     {
         $formatter = new SprintfFormatter();
@@ -30,8 +38,25 @@ class SprintfFormatterTest extends \PHPUnit_Framework_TestCase
     public function provideTypeSpecifier()
     {
         return [
-            ['s'],
-            ['-\'+-12.12f'],
+            ['b', 11, '1011'],
+            ['8b', 11, '00001011'],
+            ['0--8b', 11, '10110000'],
+            ['\'+--8b', 11, '1011++++'],
+            ['c', 32, ' '],
+            ['d', -12, '-12'],
+            ['e', '1.2', '1.200000e+0'],
+            ['E', '1.2', '1.200000E+0'],
+            ["+'+12.4f", 1.2, '++++++1.2000'],
+            ["+'+12.4F", 1.2, '++++++1.2000'],
+            ["+'+12.4g", 1.2, '+++++++++1.2' ],
+            ["+'+12.4G", 1.2, '+++++++++1.2' ],
+            ["+'+24.4g", 1.2, '+++++++++++++++++++++1.2' ],
+            ["+'+24.4G", 1.2, '+++++++++++++++++++++1.2' ],
+            ["o", 12, '14'],
+            ['s', 'test', 'test'],
+            ["u", -123, '18446744073709551493'],
+            ["x", 123, '7b'],
+            ['X', 123, '7B'],
         ];
     }
 }

--- a/tests/Formatter/SprintfFormatterTest.php
+++ b/tests/Formatter/SprintfFormatterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Budgegeria\IntlFormat\Tests\Formatter;
+
+use Budgegeria\IntlFormat\Formatter\SprintfFormatter;
+
+class SprintfFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $typeSpecifier
+     * @dataProvider provideTypeSpecifier
+     */
+    public function testHas($typeSpecifier)
+    {
+        $formatter = new SprintfFormatter();
+
+        $this->assertTrue($formatter->has($typeSpecifier));
+    }
+
+    public function testHasIsFalse()
+    {
+        $formatter = new SprintfFormatter();
+
+        $this->assertFalse($formatter->has('int'));
+    }
+
+    /**
+     * @return array
+     */
+    public function provideTypeSpecifier()
+    {
+        return [
+            ['s'],
+            ['-\'+-12.12f'],
+        ];
+    }
+}

--- a/tests/ImplementationTest.php
+++ b/tests/ImplementationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Budgegeria\IntlFormat\Tests;
+
+use Budgegeria\IntlFormat\Formatter\SprintfFormatter;
+use Budgegeria\IntlFormat\IntlFormat;
+
+class ImplementationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider formattingWorksProvider
+     */
+    public function testFormattingWorks($expected, $message, ...$args)
+    {
+        $formatter = [
+            new SprintfFormatter(),
+        ];
+
+        $intlFormat = new IntlFormat($formatter);
+
+        $this->assertSame($expected, $intlFormat->format($message, ...$args));
+    }
+
+    public function formattingWorksProvider()
+    {
+        return [
+            ['there are 12 monkeys on the 002 trees', 'there are %d %s on the %03d trees', 12, 'monkeys', 2],
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds the possibility to use sprintf-formatting in the formatter strings.

Thus it's possible to mix intl-formatting with sprintf-formatting. So it's possible to do something like this:

``` php
echo $formatter->format('those %02d %s cost %number', 2, 'monkeys', 10023.23);
// de_DE: those 02 monkeys cost 10.023,23
// en_US: those 02 monkeys cost 10,023.23
```
